### PR TITLE
Add pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "py_linenoise"
+version = "1.0.0"
+description = "A port of linenoise to Python (because sometimes readline doesn't cut it...)"
+requires-python = ">=3.8"
+authors = [
+  { name = "Jason Harris", email = "sirmanlypowers@gmail.com" }
+]
+license = { file = "LICENSE" }
+readme = "README.md"
+keywords = [
+  "linenoise",
+]
+classifiers = [
+  "Environment :: Console",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Terminals",
+]
+
+[tool.hatch.build]
+only-include = ["linenoise.py"]


### PR DESCRIPTION
This will let one use py_linenoise from a Python dependency management tool like Poetry. For example,

    poetry add git+https://github.com/dbohdan/py_linenoise

works right now.

Let me explain my decisions:

- I set the package version to 1.0 because linenoise is at version 1.0 and because py_linenoise has been stable for a long time.
- I chose [hatchling](https://hatch.pypa.io/latest/config/build/#build-system) over setuptools as the build tool. It is more standard and faster than Poetry. In setuptools support for build options in `pyproject.toml is only in beta.
- I used your name and email address from the commit history. If you are concerned about the email address being there in plain text, I can remove it. People usually include one.
- The minimum Python version of 3.8 reflects what build systems support.