### PR TITLE
Add a non-blocking API as well as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Matches the example code in the C version of the linenoise library.
 
 Implements a heirarchical command line interface using cli.py and the linenoise library.
 
+### example_non_blocking.py
+
+Shows how the non-blocking API can be used.
+
 ## Motiviation
 
 The GNU readline library is a standard package in Python, but sometimes it's hard to use:


### PR DESCRIPTION
The non-blocking API can be used by applications that need to process input from multiple sources and perform work also while waiting for user to finish writing a command.

Note that this non-blocking API currently only works for real and supported terminals. Note also that when hiding and showing the prompt we currently choose to enable and disable raw mode. This is actually not needed, it would be enough just to just reconfigure the output.